### PR TITLE
Refactored otp class

### DIFF
--- a/src/Otp.php
+++ b/src/Otp.php
@@ -11,7 +11,7 @@ class Otp extends Facade
     /**
      * @return string
      */
-    protected static function getFacadeAccessor()
+    protected static function getFacadeAccessor(): string
     {
         return 'Otp';
     }
@@ -20,26 +20,24 @@ class Otp extends Facade
      * @param string $identifier
      * @param int $digits
      * @param int $validity
+     *
      * @return mixed
      */
     protected function generate(string $identifier, int $digits = 4, int $validity = 10)
     {
         Model::where('identifier', $identifier)->where('valid', true)->delete();
-
         $token = str_pad($this->generatePin(), 4, '0', STR_PAD_LEFT);
-
-        if ($digits == 5)
+        if ($digits === 5) {
             $token = str_pad($this->generatePin(5), 5, '0', STR_PAD_LEFT);
-
-        if ($digits == 6)
+        }
+        if ($digits === 6) {
             $token = str_pad($this->generatePin(6), 6, '0', STR_PAD_LEFT);
-
+        }
         Model::create([
             'identifier' => $identifier,
             'token' => $token,
             'validity' => $validity
         ]);
-
         return response()->json([
             'status' => true,
             'token' => $token,
@@ -56,57 +54,55 @@ class Otp extends Facade
     {
         $otp = Model::where('identifier', $identifier)->where('token', $token)->first();
 
-        if ($otp == null) {
+        if ($otp === null) {
             return response()->json([
                 'status' => false,
                 'message' => 'OTP does not exist'
             ]);
-        } else {
-            if ($otp->valid == true) {
-                $carbon = new Carbon;
-                $now = $carbon->now();
-                $validity = $otp->created_at->addMinutes($otp->validity);
+        }
 
-                if (strtotime($validity) < strtotime($now)) {
-                    $otp->valid = false;
-                    $otp->save();
+        if ($otp->valid === true) {
+            $carbon = new Carbon;
+            $now = $carbon->now();
+            $validity = $otp->created_at->addMinutes($otp->validity);
 
-                    return response()->json([
-                        'status' => false,
-                        'message' => 'OTP Expired'
-                    ]);
-                } else {
-                    $otp->valid = false;
-                    $otp->save();
-
-                    return response()->json([
-                        'status' => true,
-                        'message' => 'OTP is valid'
-                    ]);
-                }
-            } else {
+            if (strtotime($validity) < strtotime($now)) {
+                $otp->valid = false;
+                $otp->save();
                 return response()->json([
                     'status' => false,
-                    'message' => 'OTP is not valid'
+                    'message' => 'OTP Expired'
                 ]);
             }
+
+            $otp->valid = false;
+            $otp->save();
+
+            return response()->json([
+                'status' => true,
+                'message' => 'OTP is valid'
+            ]);
         }
+
+        return response()->json([
+            'status' => false,
+            'message' => 'OTP is not valid'
+        ]);
     }
 
     /**
      * @param int $digits
+     *
      * @return string
      */
-    private function generatePin($digits = 4)
+    private function generatePin($digits = 4): string
     {
         $i = 0;
-        $pin = "";
-
+        $pin = '';
         while ($i < $digits) {
-            $pin .= mt_rand(0, 9);
+            $pin .= random_int(0, 9);
             $i++;
         }
-
         return $pin;
     }
 }


### PR DESCRIPTION
Refactored OTP Class.

Things done: 

- Got rid of else statements in the validate class. Why? They are not needed since you have early return statements. Only use else statements when you absolutely need too.
- Used a strict equality operator `===` as opposed to a `==`.
- Changed mt_rand() to random_int(). It is recommended to use random_int() for this purpose. Read about it [here](https://www.php.net/manual/en/function.mt-rand.php)  


Things you should consider doing:

- Create a constant file which will consist of all duplicated keys on this class. For example, you have `status`, `message` repeated in multiple places. This is not ideal for code maintainability. Your constant file should be a source of truth in case updates occurs, your key names, message text can be adjusted there without having to touch your main class.  