### PR TITLE
Change `generate` call to `validate` in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Otp::validate(string $identifier, string $token)
 ```php
 <?php
 
-$otp = Otp::generate('michael@okoh.co.uk', '282581');
+$otp = Otp::validate('michael@okoh.co.uk', '282581');
 ```
 
 #### Responses


### PR DESCRIPTION
Changed

$otp = Otp::generate('michael@okoh.co.uk', '282581');

to 

$otp = Otp::validate('michael@okoh.co.uk', '282581');