### PR TITLE
fix: CleanOtps command

### DIFF
--- a/src/Commands/CleanOtps.php
+++ b/src/Commands/CleanOtps.php
@@ -39,7 +39,7 @@ class CleanOtps extends Command
     public function handle()
     {
         try {
-            $otps = Otp::where('valid', 0)->count();
+            $otps = Otp::where('valid', 0)->orWhere('valid_until', '<', now())->count();
 
             $this->info("Found {$otps} expired otps.");
             Otp::where('valid', 0)->delete();


### PR DESCRIPTION
Check `valid_until` field while clearing expired otps