### PR TITLE
feat/add_static_method_new_for_creating_instance

### DIFF
--- a/src/Otp.php
+++ b/src/Otp.php
@@ -8,6 +8,11 @@ use Ichtrojan\Otp\Models\Otp as Model;
 
 class Otp
 {
+    public static function new(): Otp
+    {
+        return new static();
+    }
+
     /**
      * @param string $identifier
      * @param string $type


### PR DESCRIPTION
Add static method new for creating instances in Otp class

This allows for a more readable, such as 
`Otp::new()->generate('michael@okoh.co.uk', 'numeric', 6, 15); `
instead of 
`(new Otp)->generate('michael@okoh.co.uk', 'numeric', 6, 15);`