### PR TITLE
Ensure validity Value is Cast to Integer When Adding to created_at Timestamp

### DIFF
--- a/src/Otp.php
+++ b/src/Otp.php
@@ -56,7 +56,7 @@ class Otp
         if ($otp instanceof Model) {
             if ($otp->valid) {
                 $now = Carbon::now();
-                $validity = $otp->created_at->addMinutes($otp->validity);
+                $validity = $otp->created_at->addMinutes((int) $otp->validity);
 
                 $otp->update(['valid' => false]);
 


### PR DESCRIPTION
### Pull Request Description

This pull request addresses an issue where the `validity` value was not being properly cast to an integer before being added to the `created_at` timestamp. This could result in errors when the `validity` value was stored as a string in the database.

**Changes:**
- Ensure the `validity` value is cast to an integer before being used in the `validate` method.
- Update the `validate` method in the `Otp` class to properly handle the type conversion.

**Issue:**
When the `validity` value is stored as a string in the database, adding this value to the `created_at` timestamp causes an error since the `addMinutes` method expects an integer. This fix ensures that the `validity` value is always treated as an integer, preventing such errors.

**Implementation:**
```php
public function validate(string $identifier, string $token): object
{
  $otp = Model::where('identifier', $identifier)->where('token', $token)->first();

  if ($otp instanceof Model) {
    if ($otp->valid) {
      $now = Carbon::now();
      $validity = $otp->created_at->addMinutes((int) $otp->validity); // Ensure casting to int

      $otp->update(['valid' => false]);

      if (strtotime($validity) < strtotime($now)) {
        return (object) [
          'status' => false,
          'message' => 'OTP Expired'
        ];
      }

      $otp->update(['valid' => false]);

      return (object) [
        'status' => true,
        'message' => 'OTP is valid'
      ];
    }

    $otp->update(['valid' => false]);

    return (object) [
      'status' => false,
      'message' => 'OTP is invalid'
    ];
  }

  return (object) [
    'status' => false,
    'message' => 'OTP not found'
  ];
}
