### PR TITLE
use dateTime instead of timestamps

### DIFF
--- a/src/database/migrations/2019_05_11_000000_create_otps_table.php
+++ b/src/database/migrations/2019_05_11_000000_create_otps_table.php
@@ -19,7 +19,8 @@ class CreateOtpsTable extends Migration
             $table->string('token');
             $table->integer('validity');
             $table->boolean('valid')->default(true);
-            $table->timestamps();
+            $table->dateTime('created_at')->default(DB::raw('CURRENT_TIMESTAMP'));
+            $table->dateTime('updated_at')->default(DB::raw('CURRENT_TIMESTAMP'))->onUpdate(DB::raw('CURRENT_TIMESTAMP'));
         });
     }
 


### PR DESCRIPTION
The `timestamp` type has a range of 1970-01-01 00:00:01 UTC to 2038-01-19 03:14:07 UTC, while `datetime` has a range of 1000-01-01 00:00:00 to 9999-12-31 23:59:59. Therefore, `datetime` gives us a much wider range of dates -- considering the fact that we are only 14 years away from 2038.