### PR TITLE
Verify OTP without marking it as used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ use Ichtrojan\Otp\Otp;
 
 ### Check The validity of an OTP
 
-You can check the validity of an OTP without marking it as used by running the following method:
+To verify the validity of an OTP without marking it as used, you can use the `isValid` method:
 
 ```php
 <?php

--- a/README.md
+++ b/README.md
@@ -125,8 +125,9 @@ use Ichtrojan\Otp\Otp;
 You can check the validity of an OTP without marking it as used by running the following method:
 ```php
 <?php
+use Ichtrojan\Otp\Otp;
 
-(new Otp)->isValid(string $identifier, string $token)
+(new Otp)->isValid(string $identifier, string $token);
 ```
 This will return a boolean value of the validity of the OTP.
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,15 @@ use Ichtrojan\Otp\Otp;
 }
 ```
 
+### Check The validity of an OTP
+You can check the validity of an OTP without marking it as used by running the following method:
+```php
+<?php
+
+(new Otp)->isValid(string $identifier, string $token)
+```
+This will return a boolean value of the validity of the OTP.
+
 ### Delete expired tokens
 You can delete expired tokens by running the following artisan command:
 ```bash

--- a/README.md
+++ b/README.md
@@ -122,13 +122,16 @@ use Ichtrojan\Otp\Otp;
 ```
 
 ### Check The validity of an OTP
+
 You can check the validity of an OTP without marking it as used by running the following method:
+
 ```php
 <?php
 use Ichtrojan\Otp\Otp;
 
 (new Otp)->isValid(string $identifier, string $token);
 ```
+
 This will return a boolean value of the validity of the OTP.
 
 ### Delete expired tokens

--- a/src/Otp.php
+++ b/src/Otp.php
@@ -47,6 +47,27 @@ class Otp
     /**
      * @param string $identifier
      * @param string $token
+     * @return bool
+     */
+    public function isValid(string $identifier, string $token): bool
+    {
+        $otp = Model::where('identifier', $identifier)->where('token', $token)->first();
+
+        if($otp){
+            $now = Carbon::now();
+            $validity = $otp->created_at->addMinutes($otp->validity);
+
+            if( $otp->valid && (strtotime($validity) >= strtotime($now)))  {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param string $identifier
+     * @param string $token
      * @return mixed
      */
     public function validate(string $identifier, string $token): object

--- a/src/Otp.php
+++ b/src/Otp.php
@@ -56,9 +56,7 @@ class Otp
         if ($otp instanceof Model) {
             $validity = $otp->created_at->addMinutes($otp->validity);
 
-            if (Carbon::now()->lt($validity) && $otp->valid) {
-                return true;
-            }
+            return Carbon::now()->lt($validity) && $otp->valid;
         }
 
         return false;

--- a/src/Otp.php
+++ b/src/Otp.php
@@ -53,11 +53,10 @@ class Otp
     {
         $otp = Model::where('identifier', $identifier)->where('token', $token)->first();
 
-        if($otp){
-            $now = Carbon::now();
+        if ($otp instanceof Model) {
             $validity = $otp->created_at->addMinutes($otp->validity);
 
-            if( $otp->valid && (strtotime($validity) >= strtotime($now)))  {
+            if (Carbon::now()->lt($validity) && $otp->valid) {
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
Some application may only need to check the validity of the OTP before using it, so, this pull request introduces a new method **isValid** to the Otp class. The **isValid** method checks the existence and validity of an OTP (the same way you use) without marking it as used.

## Benefits

- Added isValid method to check OTP existence and validity without marking it as used.

## Usage
```php
<?php

use Ichtrojan\Otp\Otp;

(new Otp)->isValid(string $identifier, string $token);
```