### PR TITLE
Ensure 'otps' table is only created if it does not already exist

### DIFF
--- a/src/database/migrations/2019_05_11_000000_create_otps_table.php
+++ b/src/database/migrations/2019_05_11_000000_create_otps_table.php
@@ -13,14 +13,16 @@ class CreateOtpsTable extends Migration
      */
     public function up()
     {
-        Schema::create('otps', function (Blueprint $table) {
-            $table->increments('id')->index();
-            $table->string('identifier');
-            $table->string('token');
-            $table->integer('validity');
-            $table->boolean('valid')->default(true);
-            $table->timestamps();
-        });
+        if (!Schema::hasTable('otps')) {
+            Schema::create('otps', function (Blueprint $table) {
+                $table->increments('id')->index();
+                $table->string('identifier');
+                $table->string('token');
+                $table->integer('validity');
+                $table->boolean('valid')->default(true);
+                $table->timestamps();
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
This avoids the error when you run migrations. The error just tells you that the table already exists and when you go check your laravel migration scripts, there are none that matches the description - because this script here is hidden in the vendors folder and so hard to find!!